### PR TITLE
Reduce log noise, modernize file I/O, and add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.py[cod]
 
+# uv virtual environment
+.venv/
+uv.lock
+
 # C extensions
 *.so
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+PyWATER is a single-file PyMOL plugin (`pywater.py`) that finds conserved water molecules in X-ray protein structures. Given a query PDB id + chain, it fetches homologous structures from RCSB PDB, superimposes them, spatially clusters their crystallographic waters, and reports waters that recur across most structures. The whole program is `pywater.py`; `pyproject.toml`/`requirements.txt` document its NumPy/SciPy deps, and `tests/` holds a small unit suite for the non-GUI logic (run under a stubbed PyMOL — see below).
+
+## Running it
+
+PyWATER only runs inside PyMOL (it imports `pymol.cmd` at module load and cannot execute standalone). Requires NumPy and SciPy in PyMOL's Python environment.
+
+- **As a plugin**: install `pywater.py` via PyMOL's Plugin Manager (Plugins → Manage Plugins → Install), restart PyMOL. Adds a "PyWATER" GUI entry under the Plugin menu.
+- **From the PyMOL command line**: `pywater 4lyw, A, 95` (registered via `cmd.extend('pywater', toPyWATER)`).
+- **Via PyMOL's Python API**: `cmd.pywater('4lyw', 'A', ...)`.
+
+Argument order (all after PDB id and chain are optional): `PDB id, Chain id, seq_id, resolution, refinement, user_def_list, clustering_method, inconsistency_coefficient, prob`. Defaults: seq_id `95`, resolution `2.0`, refinement `Mobility`, clustering `complete`, inconsistency `2.4`, prob `0.7`.
+
+To exercise the full pipeline, launch PyMOL, run a query, and inspect the results. The non-GUI logic (RCSB response parsing, resolution sorting, structure cap / query-first selection, `toPyWATER` argument plumbing, `_LogCollector` summaries) has unit tests: `.venv/bin/python -m unittest discover -s tests` from the repo root. They import `pywater` under a stubbed PyMOL (`tests/pymol_stubs.py`), so they need only NumPy/SciPy, not a running PyMOL. `Benchmark/` and `Gallery/` hold reference outputs (per-structure result folders and PNG renderings), not test fixtures.
+
+Output goes to `~/PyWATER_outdir/` (created at import time): `pywater.log`, and a per-run subfolder `PDBid_CHAINid/` containing the query PDB with conserved waters, a `*_clusterPresence.txt` table, and (optionally) superimposed intermediate PDBs.
+
+## Architecture / control flow
+
+The pipeline lives in `FindConservedWaters()` (the entry point that both the GUI and CLI call through) → `makePDBwithConservedWaters()` (the algorithmic core). Reading these two functions top-to-bottom is the fastest way to understand the program.
+
+1. **Validation & metadata lookup** (`FindConservedWaters`): validate PDB/chain id format, confirm X-ray via `isXray()`, confirm chain exists via `chainPresent()`, range-check numeric params. All error reporting is dual: `logger.error(...)` plus a Tkinter `tkMessageBox` popup.
+2. **Building the structure set**: unless a user-defined list is given, `fetchpdbChainsList()` queries RCSB's sequence-cluster REST API for homologs at the chosen identity cutoff, then `filterbyResolution()` drops low-resolution structures. The query structure is always forced into the list.
+3. **Download & superpose** (`makePDBwithConservedWaters`): each PDB is fetched to a temp dir and loaded into PyMOL as `cwm_*` objects; `cmd.super(...////CA...)` aligns each onto the query. Water-only objects are saved per structure.
+4. **Refinement filtering**: `okMobility()` / `okBfactor()` remove poorly-refined waters per structure; a structure is discarded entirely if >50% of its waters fail. Selected via the `refinement` param (`Mobility`, `Normalized B-factor`, or `No refinement`). These read B-factor/occupancy from fixed PDB column offsets (`line[54:60]`, `line[60:66]`).
+5. **Clustering**: all retained water coordinates are pooled and clustered with `scipy.cluster.hierarchy.fclusterdata` (euclidean, `criterion='distance'`, threshold = inconsistency coefficient). Hard cap of 50000 waters.
+6. **Conservation scoring**: for each cluster, duplicate waters from the same PDB are pruned, then degree of conservation = (unique PDBs in cluster) / (total structures). Clusters at/above the `prob` cutoff and containing the query structure become conserved waters.
+7. **Output**: writes the query PDB augmented with conserved waters, and `displayInPyMOL()` renders the PyMOL session — surface, H-bond distance objects (protein/ligand/water donors & acceptors within 4.0 Å), and waters colored by conservation via `b`-factor spectrum (`red_blue`).
+
+## Conventions & gotchas
+
+- **Water identity strings**: waters are tracked as strings like `1abc_A_1234` (`pdb_chain_atomNumber`). Slicing `[:6]` extracts `pdb_ch` and `[7:]` the atom number — this positional slicing is load-bearing throughout the clustering/scoring loop. `Protein.__repr__` produces the `pdbid_chain` prefix.
+- **PyMOL object namespace**: all working objects are prefixed `cwm_` and bulk-deleted with `cmd.delete('cwm_*')` between phases. Don't introduce unprefixed temp objects into that flow.
+- **Python 2/3 compat**: the top of the file branches on `sys.version_info` for `urllib`, Tkinter, and `xrange`. Preserve this dual-support pattern when editing imports.
+- **RCSB API is stale**: the REST endpoints (`pdb.org/pdb/rest/...`, `rcsb.org/pdb/rest/...`) are legacy URLs that RCSB has since retired/changed. Network-dependent functions (`isXray`, `chainPresent`, `fetchpdbChainsList`, `filterbyResolution`, PDB file download) may fail against current RCSB services — expect this when debugging "no structures found" issues rather than assuming a logic bug.
+- **The `~/PyWATER_outdir` and logger are created at import time**, not inside a function — importing the module has filesystem side effects.

--- a/MODERNIZATION_EXECPLAN.md
+++ b/MODERNIZATION_EXECPLAN.md
@@ -1,0 +1,129 @@
+# PyWATER Modernization Execplan
+
+Date started: 2026-07-10
+
+Scope: track the ongoing modernization of `pywater.py` (single-file PyMOL
+plugin) — what is done, what remains, and important findings so future work
+does not re-litigate settled decisions.
+
+Working constraints:
+
+- Do not work directly on `master`; use `hp_*` feature branches.
+- Keep the installed plugin copy in sync after each change:
+  `cp pywater.py .venv/lib/python3.12/site-packages/pmg_tk/startup/pywater.py`
+  (PyMOL loads that copy and must be restarted to pick up changes).
+- Preserve unrelated local changes (`.gitignore`, `CLAUDE.md`).
+
+## Done
+
+### Environment / tooling (earlier sessions)
+- Open-source PyMOL 3.2.0a0 installed via `uv` into `.venv` on macOS arm64,
+  incl. the non-self-contained wheel's dylib/@rpath fix (see memory
+  `pymol-uv-install`). GUI PyMOL runs.
+
+### Merged to `master`
+- **PR #15** — migrate to modern RCSB APIs (Data/Search/GraphQL), batch
+  requests, threaded downloads. Retired the dead `customReport`/XML endpoints.
+- **PR #16** (`hp_qt_gui`) — port GUI Tkinter -> Qt (`pymol.Qt`); run the
+  search off the main thread so the GUI stays responsive; graceful
+  structure-cap guard (`DEFAULT_MAX_STRUCTURES=200`, resolution-sorted with the
+  query forced first) to stay under the 50000-water clustering limit; GUI
+  structure-selection summary.
+- **PR #17 / #18** — README + troubleshooting docs.
+- **PR #19** (`hp_modernization`) — drop Python 2 compatibility
+  (`sys.version_info`/`urllib2`/`xrange`/`xml.minidom` removed); centralize
+  RCSB HTTP helpers (`_get_json`/`_post_json`/`_graphql`, module URL/timeout
+  constants); `try/finally` temp-dir cleanup; `ImportError`/`ValueError` in
+  place of `sys.exit`/`assert`; add `pyproject.toml` + `requirements.txt`;
+  document shell CLI usage; replace `multiprocessing.dummy.Pool` with
+  `concurrent.futures.ThreadPoolExecutor`.
+
+### GitHub issue triage
+- All 6 open issues (#8, #10, #11, #12, #13, #14) closed as resolved/superseded
+  by the RCSB + Qt modernization. See `ISSUE_TRIAGE_EXECPLAN.md`. 0 open issues.
+
+### This branch (`hp_modernization_v2`) — log-noise cleanup
+- Per-structure refinement logs moved INFO -> DEBUG in `okMobility` /
+  `okBfactor` (mobility/B-factor counts, included/excluded/considered lines).
+- Added one INFO **summary** at the caller in `makePDBwithConservedWaters`:
+  `<method> refinement filtering: N of M structures retained (K discarded ...)`.
+- Downloads: per-structure "Retrieving structure" and per-failure logs moved
+  INFO/ERROR -> DEBUG; added a single WARNING summary counting skipped
+  (e.g. 404) structures. Normal runs no longer look alarming.
+- Status: code done, syntax-checked, installed copy synced. Not yet committed.
+
+### This branch (`hp_modernization_v2`) — file-I/O context managers (#5)
+- All manual `open(...)` calls now use `with` (or a list-and-write-once pattern).
+  Converted: `okMobility` / `okBfactor` (two reads + rewrite each), Protein
+  `calculate_water_coordinates`, and the conserved-waters PDB writer (nested
+  `with` over input + output).
+- The deeply-nested `clusterPresence.txt` writer (~66 lines) was NOT mass
+  re-indented (too risky); instead rows are collected into
+  `clusterPresenceLines` and written once via a small `with` block. Same
+  output, flat indentation, guaranteed close.
+- Only `urllib.urlopen` remains outside a plain `with open`, and it is already
+  context-managed. Syntax-checked, installed copy synced. Not yet committed.
+
+### This branch (`hp_modernization_v2`) — automated tests (#1)
+- Added `tests/` unit suite (stdlib `unittest`, no pytest) run under a stubbed
+  PyMOL: `tests/pymol_stubs.py` installs minimal `pymol` / `pymol.Qt` /
+  `pymol.cmd` stubs and imports `pywater`, so tests need only NumPy/SciPy.
+- 16 tests over: `_decode_response`, `filterbyResolution` (best-first sort +
+  cutoff), `_prioritize_and_cap` (query-first, cap keeps query, no-mutate),
+  `toPyWATER` arg coercion/plumbing, `_LogCollector.summary()/found_waters()`.
+- Refactor: extracted the inline query-first/cap logic from
+  `FindConservedWaters` into pure helper `_prioritize_and_cap(...)` so it is
+  unit-testable (behavior preserved; logging unchanged).
+- Run: `.venv/bin/python -m unittest discover -s tests`. All green.
+- CLAUDE.md updated (removed "no test suite"; documented how to run).
+
+## Remaining
+
+All "worth doing next" items are done. Remaining are lower-priority / later.
+
+### Probably later
+2. Split `pywater.py` into modules (GUI / network / clustering / output).
+   High-value maintainability but high-risk refactor; wait until behavior is
+   stable and tests exist.
+3. Real package/plugin install flow beyond current `pyproject.toml`.
+4. Type hints / formatting tooling (noisy, low urgency).
+5. `pathlib` adoption (cosmetic).
+
+Note: for a large deeply-nested I/O block, prefer collect-into-a-list +
+write-once through a `with` rather than re-indenting the whole block into a
+context manager — lower risk, same guarantee (used for `clusterPresence.txt`).
+
+## Important findings
+
+- **Do NOT preemptively move `cmd.*` calls back to the main thread.**
+  Codex flagged the GUI worker calling PyMOL `cmd.*` off-thread as a crash
+  risk. Investigation says otherwise:
+  - `_worker` deliberately runs `FindConservedWaters` off the main thread to
+    fix the beachball/GUI freeze; results marshal back via the `_finished`
+    Qt signal.
+  - PyMOL's `cmd.*` layer serializes calls through its own internal API lock,
+    so off-thread `cmd.load/super/create/save` is a supported pattern.
+  - The macOS SIGABRT seen earlier came from a **test harness** creating a
+    Qt/Cocoa dialog on a background thread — Cocoa window creation must be on
+    the main thread — NOT from `cmd.*` in the worker.
+  - The user tested this threaded build: "pretty fast and not hanging Mac
+    window."
+  - Fully marshaling every `cmd.*` back to the main thread would likely
+    reintroduce the freeze (all `displayInPyMOL` rendering back on the event
+    loop). Treat this as fix-when-a-real-crash-is-observed, not preemptive.
+- **RCSB downloads 404 routinely** for broad clusters; skipping them is normal,
+  not an error (drove the log-noise cleanup above).
+- **Water identity string slicing is load-bearing** (`pdb_chain_atomNumber`,
+  `[:6]`/`[7:]`) — see CLAUDE.md; don't disturb during refactors.
+- **50000-water clustering cap** is a hard memory limit (scipy O(n^2) pairwise);
+  the structure-cap guard is the mitigation.
+
+## Log
+
+- 2026-07-10: Merged PR #19. Closed all 6 issues. Started
+  `hp_modernization_v2` with log-noise cleanup (#2/#3 from Codex's remaining
+  list). This file created.
+- 2026-07-10: On `hp_modernization_v2`, converted all file I/O to context
+  managers (#5).
+- 2026-07-10: Added `tests/` unit suite (#1) + extracted `_prioritize_and_cap`
+  helper. 16 tests green. Log-noise + file-I/O + tests bundled for one PR.

--- a/pywater.py
+++ b/pywater.py
@@ -315,15 +315,17 @@ def okMobility( pdbFile, mobilityCutoff = 2.0 ):
     """
     normBfactors = []
     OccupancyAndBfactor = []
-    for line in open(pdbFile):
-        line = line.strip()
-        if line.startswith('HETATM'):
-            OccupancyAndBfactor.append([float(line[54:60]),float(line[60:66])])
+    with open(pdbFile) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('HETATM'):
+                OccupancyAndBfactor.append([float(line[54:60]),float(line[60:66])])
     occupancy = [a[0] for a in OccupancyAndBfactor]
     Bfactors = [a[1] for a in OccupancyAndBfactor]
     avgB = np.mean(Bfactors)
     avgO = np.mean(occupancy)
-    pdbFileLines = open(pdbFile).readlines()
+    with open(pdbFile) as f:
+        pdbFileLines = f.readlines()
     nWaters = len(pdbFileLines)-1
     logger.debug( 'Number of water molecules: %s' %nWaters )
     count = 0
@@ -333,20 +335,19 @@ def okMobility( pdbFile, mobilityCutoff = 2.0 ):
             if m >= mobilityCutoff:
                 count+=1
                 pdbFileLines.remove(line)
-    logger.info( 'Water oxygen atoms with a higher mobility than %s: %s: ' % (mobilityCutoff, count))
+    logger.debug( 'Water oxygen atoms with a higher mobility than %s: %s: ' % (mobilityCutoff, count))
     if count > (nWaters/2):
         considerPDB = False
     elif count > 0:
-            outfile = open(pdbFile,'w')
-            outfile.write("".join(pdbFileLines))
-            outfile.close()
+            with open(pdbFile,'w') as outfile:
+                outfile.write("".join(pdbFileLines))
             considerPDB = True
     else:
         considerPDB = True
     if considerPDB:
-        logger.info( '%s is included in the prediction.' % (pdbFile))
+        logger.debug( '%s is included in the prediction.' % (pdbFile))
     else:
-        logger.info( '%s is excluded from the prediction.' % (pdbFile))
+        logger.debug( '%s is excluded from the prediction.' % (pdbFile))
     return considerPDB
 
 def okBfactor( pdbFile, normBCutoff = 1.0 ):
@@ -358,13 +359,15 @@ def okBfactor( pdbFile, normBCutoff = 1.0 ):
     """
     Bfactors = []
     normBfactors = []
-    for line in open(pdbFile):
-        line = line.strip()
-        if line.startswith('HETATM'):
-            Bfactors.append( float(line[60:66]) )
+    with open(pdbFile) as f:
+        for line in f:
+            line = line.strip()
+            if line.startswith('HETATM'):
+                Bfactors.append( float(line[60:66]) )
     avg = np.mean( Bfactors )
     stddev = np.sqrt( np.var(Bfactors) )
-    pdbFileLines = open(pdbFile).readlines()
+    with open(pdbFile) as f:
+        pdbFileLines = f.readlines()
     nWaters = len(pdbFileLines) - 1
     logger.debug( 'Number of water molecules is : %s' %nWaters )
     count = 0
@@ -374,17 +377,16 @@ def okBfactor( pdbFile, normBCutoff = 1.0 ):
             if normB >= normBCutoff:
                 count+=1
                 pdbFileLines.remove(line)
-    logger.info( 'water oxygen atoms having higher normalized B factor are %s: '% count)
+    logger.debug( 'water oxygen atoms having higher normalized B factor are %s: '% count)
     if count > (nWaters/2):
         considerPDB = False
     elif count > 0:
-            outfile = open(pdbFile,'w')
-            outfile.write("".join(pdbFileLines))
-            outfile.close()
+            with open(pdbFile,'w') as outfile:
+                outfile.write("".join(pdbFileLines))
             considerPDB = True
     else:
         considerPDB = True
-    logger.info( '%s is considered : %s ' % (pdbFile, considerPDB))
+    logger.debug( '%s is considered : %s ' % (pdbFile, considerPDB))
     return considerPDB
 
 
@@ -404,15 +406,16 @@ class Protein():
     def calculate_water_coordinates(self, tmp_dir = False):
         path = os.path.join( tmp_dir, 'cwm_%s_Water.pdb' % self.__repr__() )
         logger.debug( 'Creating water coordinates of cwm_%s_Water.pdb.' % self.__repr__())
-        for line in open(path):
-            line = line.strip()
-            if line.startswith('HETATM'):
-                # water oxygen atom number
-                key = "%s_%s" % (self.__repr__(), int(line[22:30]))
-                coordinates = [ line[30:38], line[38:46], line[46:54] ]
-                self.waterIDCoordinates[key] = coordinates
-                self.water_coordinates.append( coordinates )
-                self.water_ids.append( key )
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('HETATM'):
+                    # water oxygen atom number
+                    key = "%s_%s" % (self.__repr__(), int(line[22:30]))
+                    coordinates = [ line[30:38], line[38:46], line[46:54] ]
+                    self.waterIDCoordinates[key] = coordinates
+                    self.water_coordinates.append( coordinates )
+                    self.water_ids.append( key )
         return self.waterIDCoordinates
 
 
@@ -519,6 +522,8 @@ def makePDBwithConservedWaters(ProteinsList, temp_dir, outdir, save_sup_files):
                     if not okBfactor(os.path.join(temp_dir, 'cwm_%s_Water.pdb' % protein)):
                         ProteinsList.proteins.remove(protein)
 
+        retained = len(ProteinsList.proteins)
+        logger.info( '%s refinement filtering: %i of %i structures retained (%i discarded for poor water refinement).' % (ProteinsList.refinement, retained, length, length - retained) )
         logger.debug( 'filtered proteins chains list is %s proteins long :' % len(ProteinsList.proteins) )
 
     """ 
@@ -571,15 +576,16 @@ def makePDBwithConservedWaters(ProteinsList, temp_dir, outdir, save_sup_files):
 
                     conservedWaterDic = {}
                     clusterPresenceDic = {}
-                    clusterPresenceOut = open(os.path.join( outdir, selectedPDBChain, '%s_clusterPresence.txt' % selectedPDBChain ),'w')
-                    clusterPresenceOut.write('Water Conservation Score'+'\t')
+                    clusterPresencePath = os.path.join( outdir, selectedPDBChain, '%s_clusterPresence.txt' % selectedPDBChain )
+                    clusterPresenceLines = []
+                    clusterPresenceLines.append('Water Conservation Score'+'\t')
                     proteins_numbers = {}
                     l=0
                     for i in ProteinsList.proteins:
                         proteins_numbers[(str(i))]=l
                         l += 1
-                        clusterPresenceOut.write('%s' % i +'\t')
-                    clusterPresenceOut.write('\n')
+                        clusterPresenceLines.append('%s' % i +'\t')
+                    clusterPresenceLines.append('\n')
                     logger.info( 'Extracting conserved waters from clusters ...' )
                     logger.debug( 'Start iterating over all clusters ...')
                     for clusterNumber, waterMols in fcDic.items():
@@ -612,22 +618,22 @@ def makePDBwithConservedWaters(ProteinsList, temp_dir, outdir, save_sup_files):
                         probability = float(uniquePDBslen) / len(ProteinsList)
                         logger.info( 'Degree of conservation is: %s' % probability )
                         if probability >= ProteinsList.probability:
-                            clusterPresenceOut.write(str(probability)+'\t')
+                            clusterPresenceLines.append(str(probability)+'\t')
                             k=0
                             for waterMol in waterMols:
                                 sr_no = proteins_numbers[waterMol[:6]]
                                 if sr_no == k:
-                                    clusterPresenceOut.write(str(waterMol[7:])+'\t')
+                                    clusterPresenceLines.append(str(waterMol[7:])+'\t')
                                     k += 1
                                 elif k < sr_no:
                                     for j in range(sr_no-k):
-                                        clusterPresenceOut.write('NoWater'+'\t')
+                                        clusterPresenceLines.append('NoWater'+'\t')
                                         k += 1
-                                    clusterPresenceOut.write(str(waterMol[7:])+'\t')
+                                    clusterPresenceLines.append(str(waterMol[7:])+'\t')
                                     k += 1
                             for j in range(len(ProteinsList.proteins)-k):
-                                clusterPresenceOut.write('NoWater'+'\t')
-                            clusterPresenceOut.write('\n')
+                                clusterPresenceLines.append('NoWater'+'\t')
+                            clusterPresenceLines.append('\n')
 
                             if selectedPDBChain in uniquePDBs:
                                 cwm_count += 1
@@ -636,7 +642,8 @@ def makePDBwithConservedWaters(ProteinsList, temp_dir, outdir, save_sup_files):
                                         conservedWaterDic[waterMol[:6]].append('_'.join([waterMol[7:], str(probability)]))
                                     else:
                                         conservedWaterDic[waterMol[:6]] = ['_'.join([waterMol[7:], str(probability)])]
-                    clusterPresenceOut.close()
+                    with open(clusterPresencePath, 'w') as clusterPresenceOut:
+                        clusterPresenceOut.write(''.join(clusterPresenceLines))
                     logger.debug( 'conservedWaterDic is: ')
                     for pdb_id, atoms in conservedWaterDic.items():
                         logger.debug('Oxygen atom numbers for %s: %s' % ( pdb_id, ', '.join( atoms ) ))
@@ -649,14 +656,14 @@ def makePDBwithConservedWaters(ProteinsList, temp_dir, outdir, save_sup_files):
                             atom, prob = probability.split('_')
                             atomNumbersProbDic[ atom ] = float( prob )
                         atomNumbers = list(atomNumbersProbDic.keys())
-                        selectedPDBChainConservedWatersOut = open(os.path.join(temp_dir, 'cwm_'+selectedPDBChain+'_ConservedWatersOnly.pdb'),'w+')
-                        selectedPDBChainIn = open(os.path.join(temp_dir, 'cwm_'+selectedPDBChain+'_Water.pdb'))
-                        for line in selectedPDBChainIn:
-                            if line.startswith('HETATM'):
-                                if str(int(line[22:30])) in atomNumbers:
-                                    selectedPDBChainConservedWatersOut.write( line )
-                        selectedPDBChainConservedWatersOut.write('END')
-                        selectedPDBChainConservedWatersOut.close()
+                        conservedWatersPath = os.path.join(temp_dir, 'cwm_'+selectedPDBChain+'_ConservedWatersOnly.pdb')
+                        waterPath = os.path.join(temp_dir, 'cwm_'+selectedPDBChain+'_Water.pdb')
+                        with open(conservedWatersPath,'w+') as selectedPDBChainConservedWatersOut, open(waterPath) as selectedPDBChainIn:
+                            for line in selectedPDBChainIn:
+                                if line.startswith('HETATM'):
+                                    if str(int(line[22:30])) in atomNumbers:
+                                        selectedPDBChainConservedWatersOut.write( line )
+                            selectedPDBChainConservedWatersOut.write('END')
 
                         # add conserved waters to pdb file
                         cmd.delete('cwm_*')
@@ -906,6 +913,25 @@ def filterbyResolution( pdbChainsList, resolutionCutoff ):
 DEFAULT_MAX_STRUCTURES = 200
 
 
+def _prioritize_and_cap(pdbChainsList, queryStr, max_structures):
+    """
+        Force the query chain to the front of the (resolution-sorted) list and
+        cap the list to the best `max_structures` entries so broad sequence
+        clusters stay within the clustering memory limit. Returns
+        (selected_list, capped_from) where capped_from is the pre-cap length if
+        a cap was applied, else None.
+    """
+    pdbChainsList = list(pdbChainsList)
+    if queryStr in pdbChainsList:
+        pdbChainsList.remove(queryStr)
+    pdbChainsList.insert(0, queryStr)
+    capped_from = None
+    if max_structures and len(pdbChainsList) > max_structures:
+        capped_from = len(pdbChainsList)
+        pdbChainsList = pdbChainsList[:max_structures]
+    return pdbChainsList, capped_from
+
+
 def FindConservedWaters(selectedStruturePDB,selectedStrutureChain,seq_id,resolution,refinement,user_def_list,clustering_method,inconsistency_coefficient,prob,save_sup_files=True,max_structures=DEFAULT_MAX_STRUCTURES):# e.g: selectedStruturePDB='3qkl',selectedStrutureChain='A'
     """
         The main function: Identification of conserved water molecules from a given protein structure.
@@ -997,20 +1023,12 @@ def FindConservedWaters(selectedStruturePDB,selectedStrutureChain,seq_id,resolut
             logger.info( 'Filtering by resolution ...')
             pdbChainsList = filterbyResolution(pdbChainsList,resolution)
             resolution_count = len(pdbChainsList)
-            # make sure query structure is not filtered out
+            # make sure query structure is not filtered out, and cap broad
+            # clusters to the best-resolution structures.
             queryStr = "%s:%s" % (selectedStruturePDB.lower(), selectedStrutureChain.upper())
-            if queryStr in pdbChainsList:
-                pdbChainsList.remove(queryStr)
-                pdbChainsList.insert(0,queryStr)
-            if queryStr not in pdbChainsList:
-                pdbChainsList.insert(0,queryStr)
-            # Added again If query structure filtered out..
-            # Cap to the best-resolution structures (the list is resolution-sorted,
-            # with the query forced to the front) so broad clusters stay within the
-            # clustering memory limit instead of failing with "too many waters".
-            if max_structures and len(pdbChainsList) > max_structures:
-                logger.info( 'Limiting to the %i best-resolution structures (out of %i) to keep clustering within memory limits.' % (max_structures, len(pdbChainsList)) )
-                pdbChainsList = pdbChainsList[:max_structures]
+            pdbChainsList, capped_from = _prioritize_and_cap(pdbChainsList, queryStr, max_structures)
+            if capped_from is not None:
+                logger.info( 'Limiting to the %i best-resolution structures (out of %i) to keep clustering within memory limits.' % (max_structures, capped_from) )
             logger.info( 'Structure selection summary: %i candidate chains, %i passed the %.2f A resolution cutoff, %i selected for clustering.' % (candidate_count, resolution_count, resolution, len(pdbChainsList)) )
             logger.debug( 'Filtered protein chains list: "%s"' % ', '.join(pdbChainsList) )
         else:
@@ -1023,28 +1041,36 @@ def FindConservedWaters(selectedStruturePDB,selectedStrutureChain,seq_id,resolut
             def download_pdb(protein):
                 pdb_path = os.path.join(tmp_dir, protein.pdb_id+'.pdb')
                 if not os.path.exists(pdb_path):
-                    logger.info('Retrieving structure: %s' % protein.pdb_id)
+                    logger.debug('Retrieving structure: %s' % protein.pdb_id)
                     url = RCSB_DOWNLOAD_URL % protein.pdb_id.upper()
                     try:
                         req = urllib.Request(url, headers=DOWNLOAD_HEADERS)
                         with urllib.urlopen(req, timeout=HTTP_TIMEOUT) as response, open(pdb_path, 'wb') as out_file:
                             out_file.write(response.read())
                     except Exception as e:
-                        logger.error("Failed to download %s: %s" % (protein.pdb_id, e))
+                        logger.debug("Failed to download %s: %s" % (protein.pdb_id, e))
 
             with ThreadPoolExecutor(max_workers=min(30, len(up.proteins))) as executor:
                 list(executor.map(download_pdb, up.proteins))
 
-            # New check: Filter out any proteins whose downloads failed
+            # Filter out any proteins whose downloads failed. Missing entries
+            # (e.g. RCSB 404s) are common for broad clusters, so each miss is
+            # logged at DEBUG and summarised once at WARNING instead of raising
+            # an alarming per-structure ERROR on otherwise-normal runs.
             successful_proteins = []
+            failed_ids = []
             for protein in up.proteins:
                 pdb_path = os.path.join(tmp_dir, protein.pdb_filename)
                 if os.path.exists(pdb_path):
                     successful_proteins.append(protein)
                 else:
-                    logger.warning('Excluding %s from superimposition because its PDB file could not be downloaded.' % protein.pdb_id)
+                    failed_ids.append(protein.pdb_id)
+                    logger.debug('Excluding %s from superimposition because its PDB file could not be downloaded.' % protein.pdb_id)
 
             up.proteins = successful_proteins
+
+            if failed_ids:
+                logger.warning('%i of %i structures could not be downloaded and were skipped (set logging to DEBUG for the list).' % (len(failed_ids), len(failed_ids) + len(successful_proteins)))
 
             if len(up.proteins) > 1:
                 logger.info( 'Save PDB file with conserved water molecules ...' )

--- a/tests/pymol_stubs.py
+++ b/tests/pymol_stubs.py
@@ -1,0 +1,64 @@
+"""
+Test bootstrap: install minimal stand-ins for PyMOL's modules so ``pywater``
+can be imported and its non-GUI logic tested under a plain Python interpreter
+(no running PyMOL). Importing this module registers the stubs and imports
+``pywater``, which it re-exports as ``pywater``.
+
+Only the attributes touched at import time are stubbed:
+- ``pymol.cmd.extend`` (called at the bottom of pywater.py),
+- ``pymol.Qt.QtWidgets.QDialog`` (base class of ConservedWaters),
+- ``pymol.Qt.QtCore.Signal`` (class attribute of ConservedWaters).
+GUI methods are not exercised by these tests.
+"""
+
+import os
+import sys
+import types
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _install_pymol_stubs():
+    if isinstance(sys.modules.get('pymol'), types.ModuleType) and \
+            getattr(sys.modules['pymol'], '_pywater_stub', False):
+        return
+
+    pymol = types.ModuleType('pymol')
+    pymol._pywater_stub = True
+
+    cmd = types.ModuleType('pymol.cmd')
+    cmd.extend = lambda name, fn: fn
+    pymol.cmd = cmd
+
+    qt = types.ModuleType('pymol.Qt')
+
+    QtWidgets = types.ModuleType('pymol.Qt.QtWidgets')
+
+    class _QDialog(object):
+        def __init__(self, *args, **kwargs):
+            pass
+
+    QtWidgets.QDialog = _QDialog
+    qt.QtWidgets = QtWidgets
+
+    QtCore = types.ModuleType('pymol.Qt.QtCore')
+    QtCore.Signal = lambda *args, **kwargs: object()
+
+    class _Qt(object):
+        WaitCursor = 0
+
+    QtCore.Qt = _Qt
+    qt.QtCore = QtCore
+
+    sys.modules['pymol'] = pymol
+    sys.modules['pymol.cmd'] = cmd
+    sys.modules['pymol.Qt'] = qt
+    sys.modules['pymol.Qt.QtWidgets'] = QtWidgets
+    sys.modules['pymol.Qt.QtCore'] = QtCore
+
+
+_install_pymol_stubs()
+
+import pywater  # noqa: E402

--- a/tests/test_pywater.py
+++ b/tests/test_pywater.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for PyWATER's non-GUI logic.
+
+Run from the repo root with:
+
+    .venv/bin/python -m unittest discover -s tests
+
+These use a stubbed PyMOL (see ``tests/pymol_stubs.py``) so they need only
+NumPy/SciPy, not a running PyMOL.
+"""
+
+import logging
+import unittest
+
+from tests.pymol_stubs import pywater as pw
+
+
+class DecodeResponseTests(unittest.TestCase):
+    class _Resp(object):
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+    def test_decodes_bytes(self):
+        self.assertEqual(pw._decode_response(self._Resp(b'{"a": 1}')), '{"a": 1}')
+
+    def test_passes_through_str(self):
+        self.assertEqual(pw._decode_response(self._Resp('already text')), 'already text')
+
+
+class FilterByResolutionTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_graphql = pw._graphql
+
+    def tearDown(self):
+        pw._graphql = self._orig_graphql
+
+    def test_sorts_best_first_and_applies_cutoff(self):
+        # 3def is above the cutoff; 4ghi has no resolution reported.
+        canned = {
+            "data": {
+                "entries": [
+                    {"rcsb_id": "1ABC", "rcsb_entry_info": {"resolution_combined": [2.0]}},
+                    {"rcsb_id": "2XYZ", "rcsb_entry_info": {"resolution_combined": [1.0]}},
+                    {"rcsb_id": "3DEF", "rcsb_entry_info": {"resolution_combined": [3.5]}},
+                    {"rcsb_id": "4GHI", "rcsb_entry_info": {}},
+                ]
+            }
+        }
+        pw._graphql = lambda query, timeout=pw.HTTP_TIMEOUT: canned
+
+        chains = ['1abc:A', '2xyz:A', '3def:A', '4ghi:A']
+        result = pw.filterbyResolution(chains, 2.5)
+
+        # Best (lowest) resolution first; over-cutoff and null-resolution dropped.
+        self.assertEqual(result, ['2xyz:A', '1abc:A'])
+
+    def test_empty_when_none_pass(self):
+        pw._graphql = lambda query, timeout=pw.HTTP_TIMEOUT: {"data": {"entries": []}}
+        self.assertEqual(pw.filterbyResolution(['1abc:A'], 2.0), [])
+
+
+class PrioritizeAndCapTests(unittest.TestCase):
+    def test_moves_query_to_front_preserving_order(self):
+        chains = ['1abc:A', '2xyz:A', '3def:A']
+        result, capped_from = pw._prioritize_and_cap(chains, '3def:A', 200)
+        self.assertEqual(result, ['3def:A', '1abc:A', '2xyz:A'])
+        self.assertIsNone(capped_from)
+
+    def test_inserts_query_when_absent(self):
+        chains = ['1abc:A', '2xyz:A']
+        result, capped_from = pw._prioritize_and_cap(chains, '9zzz:A', 200)
+        self.assertEqual(result[0], '9zzz:A')
+        self.assertIn('1abc:A', result)
+        self.assertIsNone(capped_from)
+
+    def test_caps_keeping_query_first(self):
+        chains = ['q:A'] + ['s%d:A' % i for i in range(10)]
+        result, capped_from = pw._prioritize_and_cap(chains, 'q:A', 3)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], 'q:A')
+        self.assertEqual(capped_from, 11)
+
+    def test_no_cap_when_disabled(self):
+        chains = ['a:A', 'b:A', 'c:A']
+        result, capped_from = pw._prioritize_and_cap(chains, 'a:A', 0)
+        self.assertEqual(len(result), 3)
+        self.assertIsNone(capped_from)
+
+    def test_does_not_mutate_input(self):
+        chains = ['1abc:A', '2xyz:A']
+        pw._prioritize_and_cap(chains, '2xyz:A', 200)
+        self.assertEqual(chains, ['1abc:A', '2xyz:A'])
+
+
+class ToPyWATERArgTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = pw.FindConservedWaters
+        self.captured = {}
+
+        def _spy(*args, **kwargs):
+            self.captured['args'] = args
+            self.captured['kwargs'] = kwargs
+
+        pw.FindConservedWaters = _spy
+
+    def tearDown(self):
+        pw.FindConservedWaters = self._orig
+
+    def test_defaults_and_type_coercion(self):
+        pw.toPyWATER('4LYW', 'a')
+        args = self.captured['args']
+        kwargs = self.captured['kwargs']
+        # pdb lowercased, chain uppercased
+        self.assertEqual(args[0], '4lyw')
+        self.assertEqual(args[1], 'A')
+        # seq_id stays a string; numeric params coerced
+        self.assertEqual(args[2], '95')
+        self.assertEqual(args[3], 2.0)
+        self.assertIsInstance(args[3], float)
+        self.assertEqual(args[4], 'Mobility')
+        self.assertEqual(args[8], 0.7)
+        self.assertIsInstance(args[8], float)
+        self.assertEqual(kwargs['max_structures'], pw.DEFAULT_MAX_STRUCTURES)
+        self.assertIsInstance(kwargs['max_structures'], int)
+
+    def test_explicit_values_passed_through(self):
+        pw.toPyWATER('1abc', 'B', '90', '1.5', 'No refinement', '', 'average', '2.0', '0.5', '50')
+        args = self.captured['args']
+        kwargs = self.captured['kwargs']
+        self.assertEqual(args[2], '90')
+        self.assertEqual(args[3], 1.5)
+        self.assertEqual(args[4], 'No refinement')
+        self.assertEqual(args[6], 'average')
+        self.assertEqual(args[7], 2.0)
+        self.assertEqual(kwargs['max_structures'], 50)
+
+
+class LogCollectorTests(unittest.TestCase):
+    def _record(self, msg):
+        return logging.LogRecord('PyWATER', logging.INFO, __file__, 0, msg, None, None)
+
+    def test_found_waters_true_on_success_line(self):
+        c = pw._LogCollector()
+        c.emit(self._record('Found 12 conserved water molecules.'))
+        self.assertTrue(c.found_waters())
+
+    def test_found_waters_false_otherwise(self):
+        c = pw._LogCollector()
+        c.emit(self._record('Filtering by resolution ...'))
+        self.assertFalse(c.found_waters())
+
+    def test_summary_prefers_outcome_and_includes_selection(self):
+        c = pw._LogCollector()
+        c.emit(self._record('Structure selection summary: 100 candidate chains, 40 passed, 40 selected.'))
+        c.emit(self._record('4lyw_A has too many waters to cluster. Memory is not enough...'))
+        summary = c.summary()
+        self.assertIn('too many waters to cluster', summary)
+        self.assertIn('Structure selection summary:', summary)
+
+    def test_summary_falls_back_to_selection_only(self):
+        c = pw._LogCollector()
+        c.emit(self._record('Structure selection summary: 3 candidate chains, 3 passed, 3 selected.'))
+        self.assertEqual(c.summary(), 'Structure selection summary: 3 candidate chains, 3 passed, 3 selected.')
+
+    def test_summary_default_when_nothing_matches(self):
+        c = pw._LogCollector()
+        c.emit(self._record('some unrelated debug line'))
+        self.assertIn('pywater.log', c.summary())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Follow-on modernization after PR #19. Three related, low-risk changes plus a first unit-test suite.

## Log noise (#2/#3 from the modernization backlog)
- Per-structure mobility / B-factor refinement logs moved INFO → DEBUG in `okMobility`/`okBfactor`; a single INFO summary (`<method> refinement filtering: N of M structures retained ...`) replaces them.
- Routine RCSB download misses (many 404s for broad clusters) are now DEBUG detail plus one WARNING summary, instead of a per-structure ERROR. Normal runs no longer look alarming.

## File I/O (#5)
- All manual `open()` calls converted to context managers.
- The deeply-nested `clusterPresence.txt` writer collects its rows into a list and writes once through a `with` block — same output, guaranteed close, no fragile mass re-indent.

## Tests (#1)
- New `tests/` suite (stdlib `unittest`, no pytest) run under a stubbed PyMOL (`tests/pymol_stubs.py`), so it needs only NumPy/SciPy: `​.venv/bin/python -m unittest discover -s tests`. 16 tests, all green.
- Covers `_decode_response`, `filterbyResolution` (best-first sort + cutoff), `_prioritize_and_cap` (query-first, cap keeps query, no-mutate), `toPyWATER` arg coercion/plumbing, and `_LogCollector.summary()/found_waters()`.
- Extracted the inline query-first/cap logic from `FindConservedWaters` into the pure helper `_prioritize_and_cap()` so it is unit-testable. Behavior and logging unchanged.

## Docs
- `CLAUDE.md`: removed the stale "no test suite" note; documented the test command.
- `MODERNIZATION_EXECPLAN.md`: tracking doc for this and remaining modernization work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)