### PR TITLE
Add local-files mode: conserved waters over unpublished structures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ PyWATER is a single-file PyMOL plugin (`pywater.py`) that finds conserved water 
 PyWATER only runs inside PyMOL (it imports `pymol.cmd` at module load and cannot execute standalone). Requires NumPy and SciPy in PyMOL's Python environment.
 
 - **As a plugin**: install `pywater.py` via PyMOL's Plugin Manager (Plugins → Manage Plugins → Install), restart PyMOL. Adds a "PyWATER" GUI entry under the Plugin menu.
-- **From the PyMOL command line**: `pywater 4lyw, A, 95` (registered via `cmd.extend('pywater', toPyWATER)`).
-- **Via PyMOL's Python API**: `cmd.pywater('4lyw', 'A', ...)`.
+- **From the PyMOL command line**: `pywater 4lyw, A, 95` (registered via `cmd.extend('pywater', toPyWATER)`). Note `cmd.extend` registers a *command keyword* usable as `pywater ...` in the PyMOL command language — it is **not** exposed as a `cmd.pywater(...)` attribute (that older doc claim is inaccurate; `hasattr(cmd,'pywater')` is False).
+- **Local / unpublished structures**: `pywater_local /path/to/folder, A, my_ref.pdb` (registered via `cmd.extend('pywater_local', toPyWATERLocal)`) finds conserved waters across local `.pdb` files instead of RCSB homologs. See `LOCAL_FILES_PLAN.md`.
 
 Argument order (all after PDB id and chain are optional): `PDB id, Chain id, seq_id, resolution, refinement, user_def_list, clustering_method, inconsistency_coefficient, prob`. Defaults: seq_id `95`, resolution `2.0`, refinement `Mobility`, clustering `complete`, inconsistency `2.4`, prob `0.7`.
 
@@ -22,7 +22,7 @@ Output goes to `~/PyWATER_outdir/` (created at import time): `pywater.log`, and 
 
 ## Architecture / control flow
 
-The pipeline lives in `FindConservedWaters()` (the entry point that both the GUI and CLI call through) → `makePDBwithConservedWaters()` (the algorithmic core). Reading these two functions top-to-bottom is the fastest way to understand the program.
+The pipeline lives in `FindConservedWaters()` (the RCSB entry point that the GUI and CLI call through) → `makePDBwithConservedWaters()` (the algorithmic core). Reading these two functions top-to-bottom is the fastest way to understand the program. `FindConservedWatersLocal()` is a parallel entry point for local files: it skips every RCSB step (reachability, `isXray`, `chainPresent`, `fetchpdbChainsList`, `filterbyResolution`, the cap, download), assigns each local file a synthetic 4-char id (`lc00`…, reference = `lc00`) via `collectLocalStructures()`, copies files into the temp dir, guards on chain presence (`_chainHasCA`), then converges on the same `makePDBwithConservedWaters()`. The synthetic-id scheme exists because the water-identity slicing (`[:6]`/`[7:]`) and the `cwm_????_?.pdb` glob require a 4-char id + 1-char chain.
 
 1. **Validation & metadata lookup** (`FindConservedWaters`): validate PDB/chain id format, confirm X-ray via `isXray()`, confirm chain exists via `chainPresent()`, range-check numeric params. All error reporting is dual: `logger.error(...)` plus a Tkinter `tkMessageBox` popup.
 2. **Building the structure set**: unless a user-defined list is given, `fetchpdbChainsList()` queries RCSB's sequence-cluster REST API for homologs at the chosen identity cutoff, then `filterbyResolution()` drops low-resolution structures. The query structure is always forced into the list.

--- a/LOCAL_FILES_PLAN.md
+++ b/LOCAL_FILES_PLAN.md
@@ -1,0 +1,180 @@
+# Implementation Plan — Conserved Waters from Local Files
+
+Branch: `hp_local_files`
+Date: 2026-07-10
+Status: **Implemented** — `collectLocalStructures`, `_chainHasCA`,
+`_writeLocalMap`, `FindConservedWatersLocal`, `toPyWATERLocal`
+(`pywater_local` command), and the GUI "Use local files" mode are in
+`pywater.py`. 27 unit tests pass; verified end-to-end headless on 3 real PDBs
+(40 conserved waters, mapping + friendly-named output written; bad-chain and
+missing-reference error paths confirmed).
+
+## Goal
+
+Let a crystallographer find conserved waters across a set of **local,
+unpublished structures** (files on their workstation) instead of RCSB
+homologs. Same clustering/scoring/visualization; only the *source of
+structures* changes.
+
+## Chosen UX (decided)
+
+- **Input:** a **folder path**. Every `*.pdb` in it is a comparison structure.
+- **Chain:** a **single chain id** (existing `Chain id` field) applied to all
+  files — matches the common case (same construct, chain `A`).
+- **Reference/query:** the user **types the reference filename** (option (a)).
+  Conserved waters are annotated onto and written out for this structure.
+
+Mental model:
+
+```
+Local files folder: /Users/me/my_structures/   (all *.pdb compared)
+Chain:              A                           (existing field, all files)
+Reference file:     my_apo.pdb                  (query; waters reported on it)
+```
+
+## Key constraint (load-bearing)
+
+Water identity strings are `pdbid_chain_atomNumber`, sliced positionally as
+`[:6]` (4-char id + `_` + 1-char chain) and `[7:]` throughout clustering /
+scoring. The save-superimposed glob `cwm_????_?.pdb` (pywater.py:538) and
+`pdbIdFormat` (`^[a-z0-9]{4}$`) / `chainIdFormat` (`^[A-Z0-9]$`) bake in the
+same 4-char-id + 1-char-chain shape.
+
+=> Each local file is assigned a **synthetic 4-char id** (`lc00`, `lc01`, …),
+with the reference forced to `lc00`. A mapping (synthetic id -> original
+filename) is logged and written to the output folder so results stay legible.
+Chain must be a single character (fine for normal crystallographic chains).
+
+## Scope of v1
+
+- `.pdb` files only (PDB fixed-column format — `okMobility`/`okBfactor` read
+  `line[54:60]`/`line[60:66]`). mmCIF is a follow-up (convert-on-ingest via
+  `cmd.load`+`cmd.save`).
+- Local mode is **exclusive**: these files and nothing else (no RCSB mixing).
+- Refinement filter, clustering method, inconsistency coeff., degree of
+  conservation, save-superimposed: all still apply.
+- No structure cap needed (user controls the file set), but warn if a very
+  large folder risks the 50000-water clustering limit.
+
+## Code changes
+
+### 1. Local-structure ingestion (new, pure + testable)
+
+```python
+def collectLocalStructures(local_dir, reference_filename):
+    """
+    Return (structures, query_id) where structures is an ordered list of
+    (synthetic_id, source_path) with the reference first (synthetic_id 'lc00').
+    Raises ValueError on: missing/*empty* folder, < 2 .pdb files, or a
+    reference filename not present in the folder.
+    """
+```
+
+- `glob` `*.pdb` in `local_dir` (case-insensitive), sorted for determinism.
+- Validate ≥ 2 files and that `reference_filename` (basename match) is present.
+- Assign ids: reference -> `lc00`; the rest -> `lc01`, `lc02`, … (cap the
+  count at 100 → ids stay 4 chars `lc00`..`lc99`; error if more, pointing to
+  the follow-up).
+- Return the mapping; caller copies each `source_path` -> `tmp_dir/<id>.pdb`.
+
+A separate tiny helper `_writeLocalMap(outdir, query_chain_dir, mapping)`
+writes `local_files_map.txt` and logs the table.
+
+### 2. `FindConservedWaters` — add a local branch
+
+Add trailing keyword params (keeps positional CLI/API order intact):
+
+```python
+def FindConservedWaters(..., max_structures=DEFAULT_MAX_STRUCTURES,
+                        local_files_dir=None, local_reference=None):
+```
+
+When `local_files_dir` is set:
+- **Skip** the RCSB reachability check, `isXray`, `chainPresent`,
+  `fetchpdbChainsList`, `filterbyResolution`, the cap, and the RCSB download
+  loop.
+- Still run: `chainIdFormat(chain)` and the numeric range checks.
+- `collectLocalStructures(...)` -> build `up` with synthetic ids; the query is
+  `Protein(query_id, chain)`; `selectedStruturePDB = query_id`.
+- Copy files into `tmp_dir` as `<id>.pdb`; guard each with a **chain-present /
+  has-atoms** check (load, verify `chain` exists; skip with a WARNING if not —
+  mirrors the failed-download skip, then re-check ≥ 2 remain).
+- Converge on the **existing** `makePDBwithConservedWaters(up, tmp_dir, outdir,
+  save_sup_files)` — no downstream changes.
+- After the run, also copy `<query_id>_<chain>_withConservedWaters.pdb` to a
+  friendly `<referencestem>_withConservedWaters.pdb` in the output folder.
+
+Refactor note: extract the current "populate tmp_dir + assemble `up.proteins`
++ drop failures" tail into a small internal path so the RCSB and local branches
+share the `makePDBwithConservedWaters` call and the `finally: rmtree` cleanup.
+
+### 3. GUI (`ConservedWaters` dialog)
+
+- New checkbox **"Use local files (skip RCSB)"**.
+- New **folder** `QLineEdit` + **"Browse…"** button
+  (`QtWidgets.QFileDialog.getExistingDirectory`).
+- New **reference filename** `QLineEdit`.
+- `varcheck`-style handler: when local mode is on, **disable** PDB id,
+  sequence-identity, resolution, and the user-defined-list field; **enable**
+  the folder + reference fields. (Chain, refinement, clustering, inconsistency,
+  prob, save-superimposed stay active.)
+- `run()`: in local mode, call `FindConservedWaters(local_files_dir=…,
+  local_reference=…, chain=…, …)` and ignore PDB id / seq_id / resolution.
+- Runs on the existing worker thread; `_LogCollector.summary()` gains a
+  local-mode-friendly outcome line (e.g. "No structures with chain X").
+
+### 4. CLI / Python API
+
+Avoid overloading the comma-delimited `pywater` command. Add a dedicated one:
+
+```python
+def toPyWATERLocal(folder, chain, reference,
+                   refinement='Mobility', clustering='complete',
+                   inconsistency=2.4, prob=0.7, save_sup_files=False): ...
+cmd.extend('pywater_local', toPyWATERLocal)
+```
+
+Usage: `cmd.pywater_local('/path/to/folder', 'A', 'my_apo.pdb')`.
+
+## Edge cases & validation
+
+- Folder missing / not a dir / no `.pdb` -> clear error, no crash.
+- < 2 usable files (after chain filtering) -> error (need ≥ 2 to superimpose).
+- Reference filename not in folder / lacks the chain -> error.
+- Chain id not single alphanumeric -> existing `chainIdFormat` error.
+- > 100 files -> error pointing to the (future) larger-id follow-up.
+- Reference with no waters -> existing "no conserved waters" messaging applies.
+- All popup-free (log/`_qt_info`), consistent with current error handling.
+
+## Tests (`tests/test_pywater.py`, stubbed PyMOL)
+
+Pure-Python, no `cmd`/network:
+- `collectLocalStructures`: id assignment, reference-first (`lc00`), sorted
+  order, ≥2 enforcement, reference-missing error, >100 error, non-`.pdb`
+  ignored. Use `tempfile` dirs with empty `.pdb` files.
+- `toPyWATERLocal` arg coercion/plumbing (spy on `FindConservedWaters`, assert
+  `local_files_dir`/`local_reference`/chain forwarded, numerics coerced).
+- `_LogCollector` new local outcome line.
+
+## Docs
+
+- README: new "Local / unpublished structures" section (GUI steps +
+  `pywater_local` example + the `.pdb`-only / chain caveats).
+- `docs/troubleshooting.md`: chain-not-found and <2-files notes.
+- CLAUDE.md: mention the local-files path in the control-flow section.
+- Update `MODERNIZATION_EXECPLAN.md` log.
+
+## Out of scope (follow-ups)
+
+- mmCIF input (convert-on-ingest).
+- Per-file chain selection / multi-char chains.
+- > 100 local files (needs a wider synthetic-id scheme).
+- Mixing local files with RCSB homologs.
+
+## Risk assessment
+
+Low–medium. The heavy pipeline (`makePDBwithConservedWaters` onward) is reused
+unchanged; new code is confined to structure gathering + a GUI branch. The main
+risk is the `FindConservedWaters` refactor to share the converge point — kept
+behavior-preserving for the RCSB path and covered by the existing 16 tests plus
+a manual RCSB smoke run.

--- a/MODERNIZATION_EXECPLAN.md
+++ b/MODERNIZATION_EXECPLAN.md
@@ -126,4 +126,10 @@ context manager — lower risk, same guarantee (used for `clusterPresence.txt`).
 - 2026-07-10: On `hp_modernization_v2`, converted all file I/O to context
   managers (#5).
 - 2026-07-10: Added `tests/` unit suite (#1) + extracted `_prioritize_and_cap`
-  helper. 16 tests green. Log-noise + file-I/O + tests bundled for one PR.
+  helper. 16 tests green. Log-noise + file-I/O + tests bundled for one PR (#20,
+  merged).
+- 2026-07-10: New feature on `hp_local_files` — conserved waters over local
+  unpublished `.pdb` files (`pywater_local` + GUI "Use local files" mode). See
+  `LOCAL_FILES_PLAN.md`. 27 tests green; verified headless end-to-end. Also
+  corrected the inaccurate `cmd.pywater(...)` API claim (it is a command
+  keyword, not a `cmd` attribute).

--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,43 @@ With explicit optional parameters:
 The ``-c`` flag runs PyMOL without the GUI, ``-q`` quiets startup output, and
 ``-d`` executes PyMOL commands after startup.
 
+Local / Unpublished Structures
+------------------------------
+
+If you have your own structures that are not in the PDB (e.g. unpublished
+crystal forms on your workstation), PyWATER can find conserved waters across
+those local files instead of RCSB homologs.
+
+- **GUI**: tick **"Use local files (skip RCSB)"**, set **Local files folder**
+  to a folder containing your ``.pdb`` files (use *Browse...*), set **Chain id**
+  to the chain to analyse (applied to every file), and enter the **Reference
+  file** whose conserved waters are reported. Sequence identity, resolution and
+  maximum-structures are ignored in this mode.
+
+- **Command line** (``pywater_local FOLDER, CHAIN, REFERENCE`` with optional
+  ``REFINEMENT, LINKAGE, INCONSISTENCY, CONSERVATION, SAVE_SUPERIMPOSED``):
+
+  .. code-block:: text
+
+     PyMOL> pywater_local /path/to/my_structures, A, my_apo.pdb
+
+  .. code-block:: bash
+
+     .venv/bin/pymol -cq -d "run .venv/lib/python3.12/site-packages/pmg_tk/startup/pywater.py; pywater_local /path/to/my_structures, A, my_apo.pdb"
+
+Notes:
+
+- At least two ``.pdb`` files are required; all files must share the requested
+  chain id (single character). Files lacking that chain are skipped with a
+  warning; if the reference lacks it, the run stops with an error.
+- Each file is given a short synthetic id (``lc00``, ``lc01``, ...); the
+  reference is ``lc00``. The output folder ``~/PyWATER_outdir/lc00_<chain>/``
+  contains ``local_files_map.txt`` (id → original filename) and the result as
+  both ``cwm_lc00_<chain>_withConservedWaters.pdb`` and a copy named after your
+  reference file (e.g. ``my_apo_withConservedWaters.pdb``).
+- Current limits: ``.pdb`` format only, single-character chain ids, up to 100
+  files.
+
 PyMOL Python API
 ----------------
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,6 +116,23 @@ Each run creates a subfolder such as:
 That folder contains the processed query PDB, conserved-water PDB, cluster
 presence table, and optionally the superimposed intermediate PDB files.
 
+## Local Files Mode (unpublished structures)
+
+Using "Use local files (skip RCSB)" / the `pywater_local` command:
+
+- **"Need at least 2 .pdb files"** — the folder must contain two or more `.pdb`
+  files; only files ending in `.pdb` are considered (mmCIF is not yet
+  supported).
+- **"Reference file ... is not among the .pdb files"** — the reference name
+  must match a file in the folder (basename, e.g. `my_apo.pdb`).
+- **"chain X not found" warnings / "reference does not contain chain X"** — the
+  chain id (single character) must exist in the files. All files are analysed
+  with the same chain; files missing it are skipped, and the run stops if the
+  reference itself lacks the chain.
+- Output goes to `~/PyWATER_outdir/lc00_<chain>/`, including
+  `local_files_map.txt` mapping the synthetic ids (`lc00`, `lc01`, ...) back to
+  your original filenames.
+
 ## Reporting a New Issue
 
 When reporting a new problem, include:

--- a/pywater.py
+++ b/pywater.py
@@ -220,6 +220,12 @@ Minimum suggested value is 0.5""")
 def save_sup_files_help():
     _qt_info('Save superimposed files', """Save superimposed intermediate files.""")
 
+def local_files_help():
+    _qt_info('Use local files (skip RCSB)',
+        """Find conserved waters across your own local .pdb files instead of RCSB homologs (e.g. unpublished structures on your workstation).
+Point 'Local files folder' at a folder containing at least two .pdb files (all are compared), set 'Chain id' to the chain to analyse (applied to every file), and enter the 'Reference file' whose conserved waters are reported.
+Sequence identity, resolution and maximum-structures settings are ignored in this mode. Currently supports .pdb files with single-character chain ids, up to 100 files.""")
+
 # Display imput parameters
 
 def displayInputs( selectedStruturePDB, selectedStrutureChain,
@@ -932,6 +938,143 @@ def _prioritize_and_cap(pdbChainsList, queryStr, max_structures):
     return pdbChainsList, capped_from
 
 
+# Maximum number of local files supported, bounded by the synthetic 4-char id
+# scheme (lc00..lc99). Water identity strings depend on a 4-char id + 1-char
+# chain (see the [:6]/[7:] slicing and the cwm_????_?.pdb glob).
+MAX_LOCAL_STRUCTURES = 100
+
+
+def collectLocalStructures(local_dir, reference_filename):
+    """
+        Gather local .pdb files for a conserved-water search over unpublished
+        structures. Returns an ordered list of (synthetic_id, source_path) with
+        the reference first (synthetic_id 'lc00'), plus the query id 'lc00'.
+        Each file is assigned a synthetic 4-char id (lc00..lc99) so the
+        downstream water-identity slicing keeps working. Raises ValueError on a
+        missing folder, fewer than 2 .pdb files, a reference not in the folder,
+        or more than MAX_LOCAL_STRUCTURES files.
+    """
+    if not os.path.isdir(local_dir):
+        raise ValueError('Local files folder not found: %s' % local_dir)
+    pdb_files = sorted(
+        f for f in os.listdir(local_dir)
+        if f.lower().endswith('.pdb') and os.path.isfile(os.path.join(local_dir, f))
+    )
+    if len(pdb_files) < 2:
+        raise ValueError('Need at least 2 .pdb files in %s (found %i).' % (local_dir, len(pdb_files)))
+    if len(pdb_files) > MAX_LOCAL_STRUCTURES:
+        raise ValueError('Too many local files (%i); the current limit is %i.' % (len(pdb_files), MAX_LOCAL_STRUCTURES))
+    ref_base = os.path.basename(reference_filename)
+    if ref_base not in pdb_files:
+        raise ValueError('Reference file "%s" is not among the .pdb files in %s.' % (ref_base, local_dir))
+    ordered = [ref_base] + [f for f in pdb_files if f != ref_base]
+    structures = [('lc%02d' % idx, os.path.join(local_dir, fname)) for idx, fname in enumerate(ordered)]
+    return structures, 'lc00'
+
+
+def _chainHasCA(pdb_path, chain):
+    """True if the PDB file has at least one CA atom in the given chain."""
+    try:
+        with open(pdb_path) as f:
+            for line in f:
+                if line.startswith(('ATOM', 'HETATM')) and len(line) > 21:
+                    if line[12:16].strip() == 'CA' and line[21] == chain:
+                        return True
+    except (IOError, OSError):
+        return False
+    return False
+
+
+def _writeLocalMap(outdir, selectedPDBChain, structures):
+    """Write the synthetic-id -> original-filename map so results stay legible."""
+    map_dir = os.path.join(outdir, selectedPDBChain)
+    if not os.path.exists(map_dir):
+        os.makedirs(map_dir)
+    lines = ['synthetic_id\toriginal_file']
+    lines += ['%s\t%s' % (pdb_id, os.path.basename(src)) for pdb_id, src in structures]
+    with open(os.path.join(map_dir, 'local_files_map.txt'), 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+    logger.info('Local file id mapping:\n%s' % '\n'.join(lines))
+
+
+def FindConservedWatersLocal(local_files_dir, selectedStrutureChain, local_reference, refinement='Mobility', clustering_method='complete', inconsistency_coefficient=2.4, prob=0.7, save_sup_files=True):
+    """
+        Conserved-water search over a set of LOCAL PDB files (e.g. unpublished
+        structures on the user's workstation) instead of RCSB homologs. Every
+        .pdb in local_files_dir is compared; local_reference is the query whose
+        conserved waters are reported. Reuses the same superimpose/cluster/score
+        pipeline as FindConservedWaters (via makePDBwithConservedWaters).
+    """
+    selectedStrutureChain = str(selectedStrutureChain).upper()
+    if not chainIdFormat(selectedStrutureChain):
+        return None
+    if inconsistency_coefficient > 2.8:
+        logger.info( 'The maximum allowed inconsistency coefficient threshold is 2.8 A' )
+        tkMessageBox.showinfo(title = 'Error message',
+            message = """The maximum allowed inconsistency coefficient threshold is 2.8 A.""")
+        return None
+    if prob > 1.0 or prob < 0.4:
+        logger.info( 'The degree of conservation is allowed from 0.4 A to 1.0 A.' )
+        tkMessageBox.showinfo(title = 'Error message',
+            message = """The degree of conservation is allowed from 0.4 A to 1.0 A.""")
+        return None
+    try:
+        structures, query_id = collectLocalStructures(local_files_dir, local_reference)
+    except ValueError as e:
+        logger.error('Local files error: %s' % e)
+        tkMessageBox.showinfo(title = 'Error message', message = str(e))
+        return None
+
+    displayInputs(query_id, selectedStrutureChain, 'n/a (local)', 'n/a (local)', refinement,
+        ', '.join(os.path.basename(src) for _, src in structures),
+        clustering_method, inconsistency_coefficient, prob)
+
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        up = ProteinsList(ProteinName = '.'.join([query_id, selectedStrutureChain]))
+        up.refinement = refinement
+        up.probability = prob
+        up.clustering_method = clustering_method
+        up.inconsistency_coefficient = inconsistency_coefficient
+        up.selectedPDBChain = Protein(query_id, selectedStrutureChain)
+        selectedPDBChain = str(up.selectedPDBChain)
+        logger.info( 'Local mode: %i structures from %s (query %s = %s, chain %s).' % (
+            len(structures), local_files_dir, query_id, os.path.basename(local_reference), selectedStrutureChain) )
+        for pdb_id, src in structures:
+            up.add_protein_from_string('%s:%s' % (pdb_id, selectedStrutureChain))
+            shutil.copyfile(src, os.path.join(tmp_dir, pdb_id + '.pdb'))
+
+        # Keep only structures that actually contain the requested chain.
+        usable = []
+        skipped = []
+        names = dict((pid, os.path.basename(src)) for pid, src in structures)
+        for protein in up.proteins:
+            pdb_path = os.path.join(tmp_dir, protein.pdb_filename)
+            if _chainHasCA(pdb_path, protein.chain):
+                usable.append(protein)
+            else:
+                skipped.append(protein.pdb_id)
+                logger.warning('Excluding %s (%s): chain %s not found.' % (protein.pdb_id, names.get(protein.pdb_id), protein.chain))
+        up.proteins = usable
+
+        if query_id in skipped:
+            logger.error('The reference structure %s does not contain chain %s. Choose a different reference or chain.' % (os.path.basename(local_reference), selectedStrutureChain))
+            return None
+        if len(up.proteins) > 1:
+            _writeLocalMap(outdir, selectedPDBChain, structures)
+            logger.info( 'Save PDB file with conserved water molecules ...' )
+            makePDBwithConservedWaters(up, tmp_dir, outdir, save_sup_files)
+            # Also expose the result under the reference file's name.
+            produced = os.path.join(outdir, selectedPDBChain, 'cwm_%s_withConservedWaters.pdb' % selectedPDBChain)
+            if os.path.exists(produced):
+                stem = os.path.splitext(os.path.basename(local_reference))[0]
+                shutil.copy(produced, os.path.join(outdir, selectedPDBChain, '%s_withConservedWaters.pdb' % stem))
+        else:
+            logger.error('Not enough local structures with chain %s to superimpose (need at least 2).' % selectedStrutureChain)
+    finally:
+        shutil.rmtree(tmp_dir)
+
+
 def FindConservedWaters(selectedStruturePDB,selectedStrutureChain,seq_id,resolution,refinement,user_def_list,clustering_method,inconsistency_coefficient,prob,save_sup_files=True,max_structures=DEFAULT_MAX_STRUCTURES):# e.g: selectedStruturePDB='3qkl',selectedStrutureChain='A'
     """
         The main function: Identification of conserved water molecules from a given protein structure.
@@ -1234,6 +1377,31 @@ class ConservedWaters(QtWidgets.QDialog):
             row, 2)
         row += 1
 
+        # Local files mode (skip RCSB; use the user's own structures)
+        self.use_local_files = QtWidgets.QCheckBox("Use local files (skip RCSB)")
+        self.use_local_files.stateChanged.connect(self.varcheck)
+        grid.addWidget(self.use_local_files, row, 0)
+        grid.addWidget(self._help_button(local_files_help), row, 2)
+        row += 1
+
+        grid.addWidget(QtWidgets.QLabel("Local files folder"), row, 0)
+        self.local_dir = QtWidgets.QLineEdit()
+        self.local_dir.setPlaceholderText("/path/to/folder containing .pdb files")
+        self.local_dir.setEnabled(False)
+        grid.addWidget(self.local_dir, row, 1, 1, 3)
+        self.browse_button = QtWidgets.QPushButton("Browse...")
+        self.browse_button.clicked.connect(self._browse_local_dir)
+        self.browse_button.setEnabled(False)
+        grid.addWidget(self.browse_button, row, 4)
+        row += 1
+
+        grid.addWidget(QtWidgets.QLabel("Reference file"), row, 0)
+        self.local_reference = QtWidgets.QLineEdit()
+        self.local_reference.setPlaceholderText("my_apo.pdb (query; waters reported on this)")
+        self.local_reference.setEnabled(False)
+        grid.addWidget(self.local_reference, row, 1, 1, 3)
+        row += 1
+
         # Save superimposed files
         self.save_sup = QtWidgets.QCheckBox("Save superimposed pdb files")
         grid.addWidget(self.save_sup, row, 1)
@@ -1251,39 +1419,73 @@ class ConservedWaters(QtWidgets.QDialog):
         grid.addWidget(self.status_label, row, 0, 1, 6)
 
     def varcheck(self, *args):
-        # A user-defined list disables the sequence-identity and resolution filters.
+        # A user-defined list disables the sequence-identity and resolution
+        # filters. Local-files mode disables all the RCSB-only inputs and
+        # enables the folder / reference fields instead.
+        local = self.use_local_files.isChecked()
         use = self.use_user_list.isChecked()
-        self.user_list.setEnabled(use)
-        self.resolution.setEnabled(not use)
-        self.seq_id.setEnabled(not use)
+        # Local-files widgets.
+        self.local_dir.setEnabled(local)
+        self.browse_button.setEnabled(local)
+        self.local_reference.setEnabled(local)
+        # RCSB-only widgets (chain id is used in both modes, so stays enabled).
+        self.pdb_id.setEnabled(not local)
+        self.use_user_list.setEnabled(not local)
+        self.max_structures.setEnabled(not local)
+        self.user_list.setEnabled(use and not local)
+        self.resolution.setEnabled(not use and not local)
+        self.seq_id.setEnabled(not use and not local)
+
+    def _browse_local_dir(self):
+        folder = QtWidgets.QFileDialog.getExistingDirectory(self, "Select folder with .pdb files")
+        if folder:
+            self.local_dir.setText(folder)
 
     def run(self):
         if self._worker_thread is not None and self._worker_thread.is_alive():
             return
         try:
-            resolution = float(self.resolution.text())
             inconsistency = float(self.inconsistency.text())
             prob = float(self.prob.text())
-            max_structures = int(self.max_structures.text())
         except ValueError:
             _qt_info('Invalid input',
-                'Resolution, inconsistency coefficient, degree of conservation '
-                'and maximum structures must be numbers.')
+                'Inconsistency coefficient and degree of conservation must be numbers.')
             return
 
-        args = (
-            str(self.pdb_id.text()).lower(),
-            str(self.chain_id.text()).upper(),
-            str(self.seq_id.currentText()),
-            resolution,
-            str(self.refinement.currentText()),
-            str(self.user_list.text()),
-            str(self.clustering.currentText()),
-            inconsistency,
-            prob,
-            bool(self.save_sup.isChecked()),
-            max_structures,
-        )
+        if self.use_local_files.isChecked():
+            func = FindConservedWatersLocal
+            args = (
+                str(self.local_dir.text()),
+                str(self.chain_id.text()).upper(),
+                str(self.local_reference.text()),
+                str(self.refinement.currentText()),
+                str(self.clustering.currentText()),
+                inconsistency,
+                prob,
+                bool(self.save_sup.isChecked()),
+            )
+        else:
+            try:
+                resolution = float(self.resolution.text())
+                max_structures = int(self.max_structures.text())
+            except ValueError:
+                _qt_info('Invalid input',
+                    'Resolution and maximum structures must be numbers.')
+                return
+            func = FindConservedWaters
+            args = (
+                str(self.pdb_id.text()).lower(),
+                str(self.chain_id.text()).upper(),
+                str(self.seq_id.currentText()),
+                resolution,
+                str(self.refinement.currentText()),
+                str(self.user_list.text()),
+                str(self.clustering.currentText()),
+                inconsistency,
+                prob,
+                bool(self.save_sup.isChecked()),
+                max_structures,
+            )
 
         self.run_button.setEnabled(False)
         self.status_label.setText(
@@ -1291,18 +1493,18 @@ class ConservedWaters(QtWidgets.QDialog):
             "This can take several minutes for large protein families; the "
             "window stays responsive. Progress is logged to the PyMOL console "
             "and ~/PyWATER_outdir/pywater.log.")
-        self._worker_thread = threading.Thread(target=self._worker, args=(args,))
+        self._worker_thread = threading.Thread(target=self._worker, args=(func, args))
         self._worker_thread.daemon = True
         self._worker_thread.start()
 
-    def _worker(self, args):
+    def _worker(self, func, args):
         # Runs off the main thread so the Qt GUI does not freeze. PyMOL's cmd
         # API is thread-safe; UI updates are marshalled back to the main thread
         # through the _finished signal.
         records = _LogCollector()
         logger.addHandler(records)
         try:
-            FindConservedWaters(*args)
+            func(*args)
             message = records.summary()
             success = records.found_waters()
         except Exception as e:
@@ -1336,6 +1538,22 @@ def toPyWATER( v1, v2, v3 = '95', v4 = 2.0, v5 = 'Mobility', v6 = '', v7 = 'comp
     FindConservedWaters(selectedStruturePDB,selectedStrutureChain,seq_id,resolution,refinement,user_def_list,clustering_method,inconsistency_coefficient,prob,max_structures=max_structures)
 
 
+def toPyWATERLocal( v1, v2, v3, v4 = 'Mobility', v5 = 'complete', v6 = 2.4, v7 = 0.7, v8 = False ):
+    """
+        Convert data types for the local-files command line entry point.
+        v1 = folder path, v2 = chain id, v3 = reference filename.
+    """
+    local_files_dir = str(v1)
+    selectedStrutureChain = str(v2).upper()
+    local_reference = str(v3)
+    refinement = str(v4)
+    clustering_method = str(v5)
+    inconsistency_coefficient = float(v6)
+    prob = float(v7)
+    save_sup_files = str(v8).lower() in ('1', 'true', 'yes', 'on') if not isinstance(v8, bool) else v8
+    FindConservedWatersLocal(local_files_dir, selectedStrutureChain, local_reference, refinement, clustering_method, inconsistency_coefficient, prob, save_sup_files)
+
+
 # Keep a reference so the dialog is not garbage-collected while open.
 _dialog = None
 
@@ -1353,3 +1571,4 @@ def main(parent=None):
 
 #Extends PyMOL API to use this tool from command line.
 cmd.extend('pywater', toPyWATER)
+cmd.extend('pywater_local', toPyWATERLocal)

--- a/tests/test_pywater.py
+++ b/tests/test_pywater.py
@@ -10,9 +10,25 @@ NumPy/SciPy, not a running PyMOL.
 """
 
 import logging
+import os
+import tempfile
 import unittest
 
 from tests.pymol_stubs import pywater as pw
+
+
+def _touch(path, content=''):
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def _atom_line(atomname, chain):
+    line = list(' ' * 80)
+    line[0:6] = list('ATOM  ')
+    name = atomname.ljust(4)
+    line[12:16] = list(name)
+    line[21] = chain
+    return ''.join(line) + '\n'
 
 
 class DecodeResponseTests(unittest.TestCase):
@@ -169,6 +185,101 @@ class LogCollectorTests(unittest.TestCase):
         c = pw._LogCollector()
         c.emit(self._record('some unrelated debug line'))
         self.assertIn('pywater.log', c.summary())
+
+
+class CollectLocalStructuresTests(unittest.TestCase):
+    def test_reference_first_then_sorted_ids(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ('a.pdb', 'b.pdb', 'c.pdb'):
+                _touch(os.path.join(d, name))
+            structures, query_id = pw.collectLocalStructures(d, 'b.pdb')
+            self.assertEqual(query_id, 'lc00')
+            ids = [pid for pid, _ in structures]
+            names = [os.path.basename(p) for _, p in structures]
+            self.assertEqual(ids, ['lc00', 'lc01', 'lc02'])
+            self.assertEqual(names, ['b.pdb', 'a.pdb', 'c.pdb'])  # reference first, rest sorted
+
+    def test_accepts_full_path_reference(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ('a.pdb', 'b.pdb'):
+                _touch(os.path.join(d, name))
+            structures, query_id = pw.collectLocalStructures(d, os.path.join(d, 'a.pdb'))
+            self.assertEqual(os.path.basename(structures[0][1]), 'a.pdb')
+
+    def test_ignores_non_pdb(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ('a.pdb', 'b.pdb', 'notes.txt'):
+                _touch(os.path.join(d, name))
+            structures, _ = pw.collectLocalStructures(d, 'a.pdb')
+            self.assertEqual(len(structures), 2)
+
+    def test_requires_at_least_two(self):
+        with tempfile.TemporaryDirectory() as d:
+            _touch(os.path.join(d, 'only.pdb'))
+            with self.assertRaises(ValueError):
+                pw.collectLocalStructures(d, 'only.pdb')
+
+    def test_reference_must_exist(self):
+        with tempfile.TemporaryDirectory() as d:
+            for name in ('a.pdb', 'b.pdb'):
+                _touch(os.path.join(d, name))
+            with self.assertRaises(ValueError):
+                pw.collectLocalStructures(d, 'missing.pdb')
+
+    def test_missing_folder(self):
+        with self.assertRaises(ValueError):
+            pw.collectLocalStructures('/no/such/folder/here', 'a.pdb')
+
+    def test_too_many_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            for i in range(pw.MAX_LOCAL_STRUCTURES + 1):
+                _touch(os.path.join(d, 'f%03d.pdb' % i))
+            with self.assertRaises(ValueError):
+                pw.collectLocalStructures(d, 'f000.pdb')
+
+
+class ChainHasCATests(unittest.TestCase):
+    def test_detects_chain(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, 's.pdb')
+            _touch(p, _atom_line('CA', 'A') + _atom_line('CB', 'A'))
+            self.assertTrue(pw._chainHasCA(p, 'A'))
+            self.assertFalse(pw._chainHasCA(p, 'B'))
+
+    def test_missing_file(self):
+        self.assertFalse(pw._chainHasCA('/no/such/file.pdb', 'A'))
+
+
+class ToPyWATERLocalArgTests(unittest.TestCase):
+    def setUp(self):
+        self._orig = pw.FindConservedWatersLocal
+        self.captured = {}
+
+        def _spy(*args, **kwargs):
+            self.captured['args'] = args
+            self.captured['kwargs'] = kwargs
+
+        pw.FindConservedWatersLocal = _spy
+
+    def tearDown(self):
+        pw.FindConservedWatersLocal = self._orig
+
+    def test_defaults_and_coercion(self):
+        pw.toPyWATERLocal('/data/mine', 'a', 'ref.pdb')
+        args = self.captured['args']
+        self.assertEqual(args[0], '/data/mine')
+        self.assertEqual(args[1], 'A')            # chain uppercased
+        self.assertEqual(args[2], 'ref.pdb')
+        self.assertEqual(args[3], 'Mobility')
+        self.assertEqual(args[4], 'complete')
+        self.assertEqual(args[5], 2.4)
+        self.assertIsInstance(args[5], float)
+        self.assertEqual(args[6], 0.7)
+        self.assertFalse(args[7])                 # save_sup default off
+
+    def test_save_sup_string_truthy(self):
+        pw.toPyWATERLocal('/d', 'A', 'r.pdb', 'Mobility', 'complete', 2.4, 0.7, 'true')
+        self.assertTrue(self.captured['args'][7])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements the long-standing request to run PyWATER on a crystallographer's own **local, unpublished structures** instead of RCSB homologs.

## What it does
Point PyWATER at a folder of `.pdb` files; it superimposes them, clusters their waters, and reports conserved waters on a chosen **reference** structure — reusing the exact same pipeline (`makePDBwithConservedWaters`) as the RCSB path.

## How to use
- **GUI**: tick **"Use local files (skip RCSB)"**, set the folder (Browse…), the **Chain id** (applied to all files), and the **Reference file**. Sequence-identity / resolution / max-structures are disabled in this mode.
- **Command line**: `pywater_local /path/to/folder, A, my_apo.pdb`

## Design
- `collectLocalStructures()` assigns each file a **synthetic 4-char id** (`lc00`…, reference = `lc00`). This is required because water-identity strings are sliced positionally (`[:6]`/`[7:]`) and the save-superimposed glob is `cwm_????_?.pdb` — both assume a 4-char id + 1-char chain. A `local_files_map.txt` (id → filename) is written so results stay legible, and the result is also copied to `<reference_stem>_withConservedWaters.pdb`.
- `FindConservedWatersLocal()` skips **all** RCSB steps (reachability, `isXray`, `chainPresent`, `fetchpdbChainsList`, `filterbyResolution`, cap, download), copies files into the temp dir, guards each on chain presence (`_chainHasCA`), then converges on the unchanged core. The RCSB path is untouched.
- CLI via `cmd.extend('pywater_local', toPyWATERLocal)`; GUI worker dispatches to the chosen entry point.

## Scope / limits (v1)
`.pdb` only, single-character chain ids, ≤100 files, local-only (no RCSB mixing). Follow-ups (mmCIF, per-file/multi-char chains, >100 files, hybrid) are listed in `LOCAL_FILES_PLAN.md`.

## Validation
- 27 unit tests pass (11 new: `collectLocalStructures`, `_chainHasCA`, `toPyWATERLocal`).
- End-to-end headless run on 3 real PDBs (4lyw/4qb3/6fo5, chain A) → 40 conserved waters, mapping + friendly-named output written; bad-chain and missing-reference error paths confirmed.

Also corrects the inaccurate `cmd.pywater(...)` API claim in the docs — `cmd.extend` registers a command *keyword*, not a `cmd.` attribute (`hasattr(cmd,'pywater')` is False).

🤖 Generated with [Claude Code](https://claude.com/claude-code)